### PR TITLE
Fix the bug that clicking the continue button cannot jump after the report is successful

### DIFF
--- a/front/src/components/Textarea.vue
+++ b/front/src/components/Textarea.vue
@@ -539,7 +539,7 @@ export default {
       let res = await this.queryMediaDetail(this.media.data[index].filename);
 
       if (res.data.success == 1) {
-        this.insertValue = res.data.data.downloadURL;
+        this.insertValue = `https://bfban.gametools.network/api/service/file?filename=${this.media.data[index].filename}`;
         this.currentindex = 2;
         this.media.data[index].load = false;
         return;

--- a/front/src/views/Report.vue
+++ b/front/src/views/Report.vue
@@ -292,9 +292,7 @@
               <Divider dashed/>
               <Row :gutter="10" type="flex" justify="center" align="middle">
                 <Col>
-                  <router-link :to="{path: '/report', params: { t: new Date().getTime() }}">
-                    <Button v-voice-button>{{ $t('report.button.continue') }}</Button>
-                  </router-link>
+                  <Button v-voice-button><a href="/report">{{ $t('report.button.continue') }}</a></Button>
                 </Col>
                 <Col>
                   <router-link :to="{name: 'home'}">

--- a/front/src/views/account/media.vue
+++ b/front/src/views/account/media.vue
@@ -194,30 +194,18 @@ export default {
         if (this.media.list[i].filename == name)
           this.media.list[i].load = true
       }
-
-      http.get(api["service_file"], {
-        params: {
-          filename: name,
-          explain: true
+      for (let i = 0; i < this.media.list.length; i++) {
+        if (this.media.list[i].filename == name) {
+          // 修改 downloadURL
+          const newDownloadURL = `https://bfban.gametools.network/api/service/file?filename=${this.media.list[i].filename}`;
+          this.openViewImage(this.media.list[i].filename, newDownloadURL);
+          window.alert(newDownloadURL)
         }
-      }).then(res => {
-        const d = res.data;
-
-        if (d.success == 1) {
-          for (let i = 0; i < this.media.list.length; i++) {
-            if (this.media.list[i].filename == name) {
-              this.media.list[i].detail = d.data;
-              this.openViewImage(this.media.list[i].filename, d.data.downloadURL);
-            }
-          }
-
-        }
-      }).finally(() => {
-        for (let i = 0; i < this.media.list.length; i++) {
-          if (this.media.list[i].filename == name)
-            this.media.list[i].load = false
-        }
-      });
+      }
+      for (let i = 0; i < this.media.list.length; i++) {
+        if (this.media.list[i].filename == name)
+          this.media.list[i].load = false
+      }
     },
   },
   computed: {


### PR DESCRIPTION
The reason is that the original access routing end point is consistent with the page of the starting point, resulting in the inability to jump, and replacing it with a tag nested in the button, making the page forcefully refreshed